### PR TITLE
don't raise when location is missing.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,10 @@ GEM
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
+    lograge (0.3.6)
+      actionpack (>= 3)
+      activesupport (>= 3)
+      railties (>= 3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.10)
@@ -242,6 +246,7 @@ DEPENDENCIES
   guard-rspec
   jbuilder (~> 2.0)
   jquery-rails
+  lograge
   pg
   puma (~> 2.15.3)
   pusher

--- a/app/workers/queue_listener.rb
+++ b/app/workers/queue_listener.rb
@@ -43,11 +43,17 @@ class QueueListener
   end
 
   def petition_id(params)
-    params.fetch(:petition_uri, '').match(/(\d+)\/$/)[1]
+    extract_id(params[:petition_uri])
   end
 
   def donation_id(params)
-    params.fetch(:donation_uri, '').match(/(\d+)\/$/)[1]
+    extract_id(params[:donation_uri])
+  end
+
+  def extract_id(uri)
+    id = (uri || '').match(/(\d+)\/$/){|m| m[1] if m }
+    raise ArgumentError, "Missing resource URI for page" if id.blank?
+    id
   end
 
   def create_action(params)

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -3,6 +3,29 @@ require 'rails_helper'
 describe "REST" do
   let(:page) { Page.create(title: 'Foo', slug: 'foo-bar') }
 
+  describe 'MessageHandler' do
+    describe 'update_pages' do
+      context "page does not exist on ActionKit" do
+        let(:params) do
+          {
+            type: 'update_pages',
+            petition_uri:  "",
+            donation_uri:  "",
+            params: {
+              tags: ["/rest/v1/tag/5678/"]
+            }
+          }
+        end
+
+        it 'fails' do
+          expect {
+            VCR.use_cassette('page_update_404'){ post("/message", params) }
+          }.to raise_error(ArgumentError)
+        end
+      end
+    end
+  end
+
   describe "POST /petitionpage" do
     let(:params) do
       { type: 'create',

--- a/spec/vcr_cassettes/page_update_404.yml
+++ b/spec/vcr_cassettes/page_update_404.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/petitionpage//
+    body:
+      encoding: UTF-8
+      string: '{"tags":["/rest/v1/tag/5678/"],"id":null}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 500
+      message: INTERNAL SERVER ERROR
+    headers:
+      Date:
+      - Fri, 26 Feb 2016 11:44:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Machine-Id:
+      - web-g02-03.actionkit.com
+      Vary:
+      - Cookie,Accept-Encoding,User-Agent
+    body:
+      encoding: UTF-8
+      string: '{"error": "Sorry, this request could not be processed. Please try again
+        later."}'
+    http_version: 
+  recorded_at: Fri, 26 Feb 2016 11:31:08 GMT
+- request:
+    method: put
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/donationpage//
+    body:
+      encoding: UTF-8
+      string: '{"tags":["/rest/v1/tag/5678/"],"id":null}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 500
+      message: INTERNAL SERVER ERROR
+    headers:
+      Date:
+      - Fri, 26 Feb 2016 11:44:32 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Machine-Id:
+      - web-g02-03.actionkit.com
+      Vary:
+      - Cookie,Accept-Encoding,User-Agent
+    body:
+      encoding: UTF-8
+      string: '{"error": "Sorry, this request could not be processed. Please try again
+        later."}'
+    http_version: 
+  recorded_at: Fri, 26 Feb 2016 11:31:09 GMT
+recorded_with: VCR 3.0.1

--- a/spec/workers/queue_listener_spec.rb
+++ b/spec/workers/queue_listener_spec.rb
@@ -61,6 +61,27 @@ describe QueueListener do
         expect(client).to receive(:update_petition_page).with(expected_params)
         subject.perform(nil, params)
       end
+
+      context 'without resource URI' do
+        before do
+          params[:petition_uri] = nil
+        end
+
+        let(:expected_params) do
+          {
+            tags: ["/rest/v1/tag/5678/"],
+            id: nil
+          }
+        end
+
+        it "raises argument error" do
+          expect(client).not_to receive(:update_petition_page).with(expected_params)
+
+          expect{
+            subject.perform(nil, params)
+           }.to raise_error(ArgumentError, /Missing resource URI/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Handle empty resource URIs and Return 200 to queue for failed page updates.