### PR TITLE
Add ActionsCache backed by ActionsCache::Store

### DIFF
--- a/app/workers/queue_listener.rb
+++ b/app/workers/queue_listener.rb
@@ -81,13 +81,16 @@ class QueueListener
 
     action = Action.find_by_id(params[:meta][:action_id])
     response = client.create_action(params[:params])
+    payload = params[:meta].merge(type: 'petition')
 
     if action
       action[:form_data][:ak_resource_id] = response['resource_uri']
       action.save
     end
 
-    Broadcast.emit( params[:meta].merge(type: 'petition' ) )
+    Broadcast.emit(payload)
+    ActionsCache.append(payload)
+
     response
   end
 

--- a/circle/docker-compose-template.yml
+++ b/circle/docker-compose-template.yml
@@ -2,6 +2,7 @@ processor:
   image: "soutech/champaign-ak-processor:$CIRCLE_SHA1"
   links:
     - db
+    - redis
   command: /myapp/circle/run-tests
   env_file:
     - test.env
@@ -12,3 +13,6 @@ db:
     - "5432"
   environment:
     POSTGRES_DB: champaign_test
+redis:
+  image: redis
+  command: redis-server --protected-mode no

--- a/circle/test.env
+++ b/circle/test.env
@@ -5,3 +5,5 @@ AK_USERNAME=ak_username
 AK_PASSWORD=ak_password
 HPC_RULE_ID=22
 AK_SUBSCRIPTION_PAGE_NAME='registration'
+REDIS_URI=redis
+REDIS_PORT=6379

--- a/config/env.yml.template
+++ b/config/env.yml.template
@@ -4,3 +4,4 @@ AK_USERNAME: 'username'
 AK_HOST: 'https://act.sumofus.org/'
 HPC_RULE_ID: '22'
 AK_SUBSCRIPTION_PAGE_NAME: 'registration'
+ACTIONS_CACHE_SIZE: 100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,3 @@ db:
     - "5432"
   environment:
       POSTGRES_DB: champaign
-
-redis:
-  image: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,6 @@ db:
     - "5432"
   environment:
       POSTGRES_DB: champaign
+
+redis:
+  image: redis

--- a/lib/actions_cache.rb
+++ b/lib/actions_cache.rb
@@ -1,0 +1,44 @@
+module ActionsCache
+
+  def self.append(payload)
+    @store ||= ActionsCache::Store.new(ENV['ACTIONS_CACHE_SIZE'].to_i)
+    @store.append(payload)
+  end
+
+  # ActionsCache::Store can
+  class Store
+    attr_accessor :redis
+    attr_accessor :cache_size
+    attr_accessor :namespace
+
+    def initialize(cache_size = 100, namespace = 'champaign:actions:cache')
+      @redis = RedisClient.client
+      @cache_size = cache_size
+      @namespace = namespace
+    end
+
+    # Append an item to the set and respect @cache_size (deletes extra)
+    def append(payload)
+      result = redis.zadd(namespace, Time.now.to_i, payload.to_json)
+      remrange(0, ((cache_size + 1) * -1))
+      result
+    end
+
+    # Utility method to remove items by rank
+    def remrange(from, to)
+      result = redis.zremrangebyrank(namespace, from, to)
+      result
+    end
+
+    # Clear the entire ordered set
+    def clear
+      remrange(0, -1)
+    end
+
+    def actions
+      actions = redis.zrange(namespace, 0, -1)
+      actions
+    end
+
+  end
+end

--- a/spec/lib/actions_cache_spec.rb
+++ b/spec/lib/actions_cache_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+describe ActionsCache::Store do
+  describe :initialize do
+    it 'sets the redis client instance on initialization' do
+      actions_cache = ActionsCache::Store.new
+      expect(actions_cache.redis).to be_an_instance_of(Redis)
+    end
+
+    it 'defaults to a cache size of 100' do
+      actions_cache = ActionsCache::Store.new
+      expect(actions_cache.cache_size).to eq(100)
+    end
+
+    it 'accepts a cache_size' do
+      actions_cache = ActionsCache::Store.new(10)
+      expect(actions_cache.cache_size).to eq(10)
+    end
+
+    it 'sets a default readable namespace (redis ordered set name)' do
+      actions_cache = ActionsCache::Store.new
+      expect(actions_cache.namespace).to eq('champaign:actions:cache')
+    end
+  end
+
+  describe :actions do
+    after { ActionsCache::Store.new.clear }
+
+    it 'returns all stored actions' do
+      actions_cache = ActionsCache::Store.new
+      expect(actions_cache.actions).to be_a_kind_of(Enumerable)
+    end
+
+    it 'returns them in chronological order' do
+      actions_cache = ActionsCache::Store.new
+
+      3.times do |i|
+        actions_cache.append({ item: "##{i}" })
+      end
+
+      expect(actions_cache.actions.first).to match(/\#0/)
+      expect(actions_cache.actions.last).to match(/\#2/)
+    end
+  end
+
+  describe :append do
+    before do
+      @size = 5
+      @actions_cache = ActionsCache::Store.new(@size)
+      @redis = @actions_cache.redis
+      @payload = { foo: 'bar' }
+    end
+
+    after { ActionsCache::Store.new.clear }
+
+    it 'adds a payload to an ordered set' do
+      @actions_cache.append(@payload)
+      expect(@actions_cache.actions.count).to eq(1)
+    end
+
+    it 'will trim the set if it exceeds its :cache_size' do
+      10.times do |i|
+        payload = { foo: "Item ##{i}" }
+        @actions_cache.append(payload)
+      end
+
+      expect(@actions_cache.actions.count).to eq(5)
+    end
+  end
+
+  describe :remrange do
+    before do
+      @actions_cache = ActionsCache::Store.new(10)
+      10.times do |i|
+        payload = { foo: "Item ##{i}" }
+        @actions_cache.append(payload)
+      end
+    end
+
+    after { @actions_cache.clear }
+
+    it 'removes a range of items from the ordered set' do
+      @actions_cache.remrange(0, -2)
+      expect(@actions_cache.actions.count).to eq(1)
+    end
+  end
+
+  describe :clear do
+    before do
+      @actions_cache = ActionsCache::Store.new(10)
+      10.times do |i|
+        payload = { foo: "Item ##{i}" }
+        @actions_cache.append(payload)
+      end
+    end
+
+    after { @actions_cache.clear }
+
+    it 'clears the entire set' do
+      expect(@actions_cache.actions.count).to eq(10)
+      @actions_cache.clear
+      expect(@actions_cache.actions.count).to eq(0)
+    end
+  end
+end
+

--- a/spec/requests/actions_spec.rb
+++ b/spec/requests/actions_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe "REST" do
   before do
     allow(Broadcast).to receive(:emit)
+    allow(ActionsCache).to receive(:append)
   end
 
   let(:action) { Action.create(form_data: {}) }
@@ -172,6 +173,12 @@ describe "REST" do
         it 'publishes action' do
           expect(Broadcast).to have_received(:emit).with(
             hash_including({ foo: 'bar', type: 'petition' })
+          )
+        end
+
+        it 'stores the action in ActionCache' do
+          expect(ActionsCache).to have_received(:append).with(
+            hash_including(foo: 'bar', type: 'petition')
           )
         end
 


### PR DESCRIPTION
`ActionsCache` behaves like a singleton (since the store is persistent) but under the hood it uses `ActionsCache::Store`, which allows us to specify the maximum cache size, and the namespace/key

Unit tests have been added mainly for the store. In `actions_spec.rb` I'm only mocking and checking that we send `:append` to `ActionsCache`