### PR TITLE
Add ability to create multilingual campaigns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ env.yml
 !.elasticbeanstalk/*.global.yml
 .DS_Store
 .byebug_history
+.ruby-gemset

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'redis'
-gem 'actionkit_connector', github: 'SumOfUs/actionkit_connector'
+gem 'actionkit_connector', github: 'SumOfUs/actionkit_connector', branch: 'campaigns' #TODO Remove branch once merged
 gem 'puma', '~> 2.15.3'
 gem 'aws-sdk'
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'redis'
-gem 'actionkit_connector', github: 'SumOfUs/actionkit_connector', branch: 'campaigns' #TODO Remove branch once merged
+gem 'actionkit_connector', github: 'SumOfUs/actionkit_connector'
 gem 'puma', '~> 2.15.3'
 gem 'aws-sdk'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: git://github.com/SumOfUs/actionkit_connector.git
-  revision: 129c0ad4b61d124305491894da58b28694c0d205
-  branch: campaigns
+  revision: d49b9a9dd5e01797e9d313f232cc256c14df65a0
   specs:
     actionkit_connector (0.4.3)
       httparty (~> 0.13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: git://github.com/SumOfUs/actionkit_connector.git
-  revision: 59635437d6b9d32e22fa4d7704b1cff061feea62
+  revision: 129c0ad4b61d124305491894da58b28694c0d205
+  branch: campaigns
   specs:
     actionkit_connector (0.4.3)
       httparty (~> 0.13)
@@ -91,8 +92,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.0)
-    httparty (0.13.7)
-      json (~> 1.8)
+    httparty (0.14.0)
       multi_xml (>= 0.5.2)
     httpclient (2.7.1)
     i18n (0.7.0)
@@ -261,5 +261,8 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/services/campaign_creator.rb
+++ b/app/services/campaign_creator.rb
@@ -1,0 +1,20 @@
+class CampaignCreator
+  class Error < StandardError; end
+  include Ak::Client
+
+  def self.run(params)
+    new(params).run
+  end
+
+  def initialize(params)
+    @params = params.slice(:name)
+  end
+
+  def run
+    client.create_multilingual_campaign(@params).tap do |response|
+      if response.code != 201
+        raise Error.new("HTTP Response code: #{response.code}, body: #{response.body}")
+      end
+    end
+  end
+end

--- a/app/workers/queue_listener.rb
+++ b/app/workers/queue_listener.rb
@@ -7,6 +7,7 @@ class QueueListener
   UPDATE_PAGES    = 'update_pages'
   SUBSCRIPTION_PAYMENT = 'subscription-payment'
   SUBSCRIBE_MEMBER = 'subscribe_member'
+  CREATE_CAMPAIGN = 'create_campaign'
 
   def perform(sqs_message, params)
     case params[:type]
@@ -27,6 +28,9 @@ class QueueListener
 
       when SUBSCRIBE_MEMBER
         subscribe_member(params)
+
+      when CREATE_CAMPAIGN
+        CampaignCreator.run(params)
 
       else
         raise ArgumentError, "Unsupported message type: #{params[:type]}"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/requests/campaigns_spec.rb
+++ b/spec/requests/campaigns_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe "Campaigns", type: :request do
+
+  describe "#create" do
+
+    context "given valid params" do
+      it "responds 200 OK" do
+        VCR.use_cassette "create_multilingual_campaign_200" do
+          post '/message', type: 'create_campaign', name: 'Test Campaign 4'
+        end
+        expect(response.code).to eq "200"
+      end
+    end
+
+    context "given invalid params" do
+      it "responds 500 Internal Server Error" do
+        VCR.use_cassette "create_multilingual_campaign_400" do
+          post '/message', type: 'create_campaign', name: ''
+          expect(response.code).to eq "500"
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'rails_helper'
 
 describe "REST" do
   let(:page) { Page.create(title: 'Foo', slug: 'foo-bar') }
@@ -32,10 +33,9 @@ describe "REST" do
           VCR.use_cassette('page_update_404'){ post("/message", params) }
         end
 
-        it 'fails' do
-          expect {
-            subject
-          }.to raise_error(ArgumentError)
+        it 'responds 500 Internal Server Error' do
+          subject
+          expect(response.code).to eq('500')
         end
 
       end

--- a/spec/services/campaign_creator_spec.rb
+++ b/spec/services/campaign_creator_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe CampaignCreator do
+  context "given valid params" do
+    it "returns a response object with 201 Created status" do
+      VCR.use_cassette "create_multilingual_campaign_200" do
+        response = CampaignCreator.run(name: "Test Campaign 4")
+        expect(response.code).to eq 201
+      end
+    end
+  end
+
+  context "given invalid params" do
+    it "raises a CampaignCreator::Error" do
+      VCR.use_cassette "create_multilingual_campaign_400" do
+        expect {
+          CampaignCreator.run(name: "Test Campaign 4")
+        }.to raise_error(CampaignCreator::Error)
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/create_multilingual_campaign_200.yml
+++ b/spec/vcr_cassettes/create_multilingual_campaign_200.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/multilingualcampaign/
+    body:
+      encoding: UTF-8
+      string: '{"name":"Test Campaign 4"}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Sun, 31 Jul 2016 20:44:35 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Machine-Id:
+      - web-g02-02.actionkit.com
+      Vary:
+      - Accept,Cookie,Accept-Encoding,User-Agent
+      Location:
+      - https://act.sumofus.org/rest/v1/multilingualcampaign/118/
+      Set-Cookie:
+      - sid=fwof3e9353l8prj5zbh73xk56477bc7z; expires=Mon, 01-Aug-2016 04:44:35 GMT;
+        httponly; Max-Age=28800; Path=/
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 31 Jul 2016 20:44:36 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/create_multilingual_campaign_400.yml
+++ b/spec/vcr_cassettes/create_multilingual_campaign_400.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/multilingualcampaign/
+    body:
+      encoding: UTF-8
+      string: '{"name":""}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 400
+      message: BAD REQUEST
+    headers:
+      Date:
+      - Sun, 31 Jul 2016 21:53:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Machine-Id:
+      - web-g02-01.actionkit.com
+      Vary:
+      - Cookie,Accept-Encoding,User-Agent
+      Set-Cookie:
+      - sid=kajzhi1uxh2tndvy2p8g319ytikbww4z; expires=Mon, 01-Aug-2016 05:53:57 GMT;
+        httponly; Max-Age=28800; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"multilingualcampaign": {"name": ["This field is required."]}}'
+    http_version: 
+  recorded_at: Sun, 31 Jul 2016 21:53:57 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
I updated the test.env config so Request specs don't raise exceptions and just return 500 errors as in production. IMO the raising of exceptions should be tested in unit tests.

**Note:** After merging https://github.com/SumOfUs/actionkit_connector/pull/5 update Gemfile to use master branch.

