### PR TITLE
Retry with random suffix on name collisions for campaigns

### DIFF
--- a/app/services/campaign_creator.rb
+++ b/app/services/campaign_creator.rb
@@ -7,17 +7,37 @@ class CampaignCreator
   end
 
   def initialize(params)
-    @params = params.slice(:name)
+    @params = params
     @campaign_id = params[:campaign_id] || raise(ArgumentError)
+    @retry_count = 0
   end
 
   def run
-    client.create_multilingual_campaign(@params).tap do |response|
-      if response.success?
-        CampaignRepository.set(@campaign_id, response.headers['location'])
-      else
-        raise Error.new("HTTP Response code: #{response.code}, body: #{response.body}")
+    response = client.create_multilingual_campaign(sanitized_params)
+    if response.success?
+      CampaignRepository.set(@campaign_id, response.headers['location'])
+      response
+    elsif name_uniqueness_error?(response)
+      @retry_count += 1
+      run
+    else
+      raise Error.new("HTTP Response code: #{response.code}, body: #{response.body}")
+    end
+  end
+
+  private
+
+  def name_uniqueness_error?(response)
+    response.code == 409 &&
+      response.parsed_response.dig('errors', 'name').grep(/Conflict on unique key 'name'/).any?
+  end
+
+  def sanitized_params
+    @params.slice(:name).tap do |params|
+      if @retry_count > 0
+        params[:name] = "#{params[:name]}-#{rand(1000)}"
       end
     end
   end
+
 end

--- a/app/services/campaign_updater.rb
+++ b/app/services/campaign_updater.rb
@@ -7,17 +7,38 @@ class CampaignUpdater
   end
 
   def initialize(params)
-    @params = params.slice(:name)
+    @params = params
     @campaign_id = params[:campaign_id] || raise(ArgumentError)
+    @retry_count = 0
   end
 
   def run
     ak_campaign_uri = CampaignRepository.get!(@campaign_id)
     ak_campaign_id = ActionKitConnector::Util.extract_id_from_resource_uri(ak_campaign_uri)
 
-    client.update_multilingual_campaign(ak_campaign_id, @params).tap do |response|
-      if !response.success?
-        raise Error.new("HTTP Response code: #{response.code}, body: #{response.body}")
+    response = client.update_multilingual_campaign(ak_campaign_id, sanitized_params)
+    if response.success?
+      response
+    elsif name_uniqueness_error?(response)
+      @retry_count += 1
+      run
+    else
+      raise Error.new("HTTP Response code: #{response.code}, body: #{response.body}")
+    end
+  end
+
+  private
+
+  #DUP name-uniqueness
+  def name_uniqueness_error?(response)
+    response.code == 409 &&
+      response.parsed_response.dig('errors', 'name').grep(/Conflict on unique key 'name'/).any?
+  end
+
+  def sanitized_params
+    @params.slice(:name).tap do |params|
+      if @retry_count > 0
+        params[:name] = "#{params[:name]}-#{rand(1000)}"
       end
     end
   end

--- a/spec/services/campaign_creator_spec.rb
+++ b/spec/services/campaign_creator_spec.rb
@@ -32,4 +32,21 @@ describe CampaignCreator do
       end
     end
   end
+
+  context "given a campaign with the passed name already exists" do
+    before do
+      # Hardcoding rand so the suffix is always the same and plays well with VCR
+      allow_any_instance_of(Object).to receive(:rand).and_return(123)
+    end
+
+    it "appends a random number suffix to the name and retries" do
+      VCR.use_cassette "create_multilingual_campaign_retry" do
+        response = CampaignCreator.run(campaign_id: 123, name: "Test Campaign 6")
+        expect(response).to be_success
+
+        response = CampaignCreator.run(campaign_id: 123, name: "Test Campaign 6")
+        expect(response).to be_success
+      end
+    end
+  end
 end

--- a/spec/services/campaign_updater_spec.rb
+++ b/spec/services/campaign_updater_spec.rb
@@ -27,4 +27,21 @@ describe CampaignUpdater do
       end
     end
   end
+
+  context "given another campaign exists with the same name" do
+    before do
+      # Hardcoding rand so the suffix is always the same and plays well with VCR
+      allow_any_instance_of(Object).to receive(:rand).and_return(123)
+    end
+
+    it "appends a random number suffix to the name and retries" do
+      VCR.use_cassette "update_multilingual_campaign_retry" do
+        response = CampaignCreator.run name: "Test Campaign 1236", campaign_id: 12
+        expect(response).to be_success
+
+        response = CampaignUpdater.run name: 'Test Campaign 1236', campaign_id: 1234
+        expect(response).to be_success
+      end
+    end
+  end
 end

--- a/spec/vcr_cassettes/create_multilingual_campaign_retry.yml
+++ b/spec/vcr_cassettes/create_multilingual_campaign_retry.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/multilingualcampaign/
+    body:
+      encoding: UTF-8
+      string: '{"name":"Test Campaign 6"}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 04 Aug 2016 20:15:40 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Machine-Id:
+      - web-g02-03.actionkit.com
+      Vary:
+      - Accept,Cookie,Accept-Encoding,User-Agent
+      Location:
+      - https://act.sumofus.org/rest/v1/multilingualcampaign/131/
+      Set-Cookie:
+      - sid=1geshzx4h2kh2jbkmi964khoq2v8bkio; expires=Fri, 05-Aug-2016 04:15:40 GMT;
+        httponly; Max-Age=28800; Path=/
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 04 Aug 2016 20:15:42 GMT
+- request:
+    method: post
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/multilingualcampaign/
+    body:
+      encoding: UTF-8
+      string: '{"name":"Test Campaign 6"}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 409
+      message: CONFLICT
+    headers:
+      Date:
+      - Thu, 04 Aug 2016 20:15:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Machine-Id:
+      - web-g02-02.actionkit.com
+      Vary:
+      - Cookie,Accept-Encoding,User-Agent
+      Location:
+      - https://act.sumofus.org/rest/v1/multilingualcampaign/131/
+      Set-Cookie:
+      - sid=iwopjn5j199tg60nuhv3c26eci57xzs2; expires=Fri, 05-Aug-2016 04:15:43 GMT;
+        httponly; Max-Age=28800; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"errors": {"name": ["Conflict on unique key ''name'' for value ''Test
+        Campaign 6'', existing location: /rest/v1/multilingualcampaign/131/"]}}'
+    http_version: 
+  recorded_at: Thu, 04 Aug 2016 20:15:43 GMT
+- request:
+    method: post
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/multilingualcampaign/
+    body:
+      encoding: UTF-8
+      string: '{"name":"Test Campaign 6-123"}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 04 Aug 2016 20:15:45 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Machine-Id:
+      - web-g02-02.actionkit.com
+      Vary:
+      - Accept,Cookie,Accept-Encoding,User-Agent
+      Location:
+      - https://act.sumofus.org/rest/v1/multilingualcampaign/132/
+      Set-Cookie:
+      - sid=n0sflxxhbha3p4ppob4vh79odrtapo1t; expires=Fri, 05-Aug-2016 04:15:45 GMT;
+        httponly; Max-Age=28800; Path=/
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 04 Aug 2016 20:15:45 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/update_multilingual_campaign_retry.yml
+++ b/spec/vcr_cassettes/update_multilingual_campaign_retry.yml
@@ -1,0 +1,116 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/multilingualcampaign/
+    body:
+      encoding: UTF-8
+      string: '{"name":"Test Campaign 1236"}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 04 Aug 2016 20:49:39 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Machine-Id:
+      - web-g02-03.actionkit.com
+      Vary:
+      - Accept,Cookie,Accept-Encoding,User-Agent
+      Location:
+      - https://act.sumofus.org/rest/v1/multilingualcampaign/134/
+      Set-Cookie:
+      - sid=dd2bjbd289icv566e8de50zftlaljtlb; expires=Fri, 05-Aug-2016 04:49:39 GMT;
+        httponly; Max-Age=28800; Path=/
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 04 Aug 2016 20:49:41 GMT
+- request:
+    method: put
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/multilingualcampaign/120/
+    body:
+      encoding: UTF-8
+      string: '{"name":"Test Campaign 1236"}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 409
+      message: CONFLICT
+    headers:
+      Date:
+      - Thu, 04 Aug 2016 20:49:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Machine-Id:
+      - web-g02-02.actionkit.com
+      Vary:
+      - Cookie,Accept-Encoding,User-Agent
+      Location:
+      - https://act.sumofus.org/rest/v1/multilingualcampaign/134/
+      Set-Cookie:
+      - sid=0evfejp5elrxx17sgbnqk1qhaed1bxyf; expires=Fri, 05-Aug-2016 04:49:43 GMT;
+        httponly; Max-Age=28800; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"errors": {"name": ["Conflict on unique key ''name'' for value ''Test
+        Campaign 1236'', existing location: /rest/v1/multilingualcampaign/134/"]}}'
+    http_version: 
+  recorded_at: Thu, 04 Aug 2016 20:49:43 GMT
+- request:
+    method: put
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/multilingualcampaign/120/
+    body:
+      encoding: UTF-8
+      string: '{"name":"Test Campaign 1236-123"}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 204
+      message: NO CONTENT
+    headers:
+      Date:
+      - Thu, 04 Aug 2016 20:49:44 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Machine-Id:
+      - web-g02-01.actionkit.com
+      Vary:
+      - Accept,Cookie,Accept-Encoding,User-Agent
+      Set-Cookie:
+      - sid=330y6b2rz01wqy5h3qrcx4eyciulyttk; expires=Fri, 05-Aug-2016 04:49:44 GMT;
+        httponly; Max-Age=28800; Path=/
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 04 Aug 2016 20:49:45 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
There's some code duplication in `CampaignCreator` and `CampaignUpdater`, but I'd prefer to wait before extracting an abstraction to remove that duplication. I'd like to implement this same feature with Pages as well, I think that will give us more insight on how to extract this duplicate behaviour involving retries and adding a suffix to the name. 