### PR TITLE
Process new survey response events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/SumOfUs/actionkit_connector.git
-  revision: d0a14ddd266abac6f650ecb4fb00baf30721acd3
+  revision: fbc1b57b90af7a594c1d4bcfea1e76b835bdefd4
   branch: master
   specs:
     actionkit_connector (0.4.4)

--- a/app/models/action_repository.rb
+++ b/app/models/action_repository.rb
@@ -1,16 +1,22 @@
 class ActionRepository
   class NotFoundError < StandardError; end
 
-  def self.set(ch_action_id, ak_action_id)
-    redis.set("action:#{ch_action_id}", ak_action_id)
+  # ch_id => champaign id
+  # ak id => action_kit id
+  def self.set(ch_id, ak_id:, page_ak_id:)
+    redis.hmset("action:#{ch_id}", :ak_id, ak_id, :page_ak_id, page_ak_id)
   end
 
-  def self.get(ch_action_id)
-    redis.get("action:#{ch_action_id}")
+  def self.get(ch_id)
+    redis.hgetall("action:#{ch_id}").symbolize_keys!
   end
 
-  def self.get!(ch_action_id)
-    get(ch_action_id) || raise(NotFoundError.new "Can't find action with id: #{ch_action_id}")
+  def self.get!(ch_id)
+    action = get(ch_id)
+    if action.empty?
+      raise NotFoundError.new("Can't find action with id: #{ch_id}")
+    end
+    action
   end
 
   def self.redis

--- a/app/models/action_repository.rb
+++ b/app/models/action_repository.rb
@@ -1,0 +1,19 @@
+class ActionRepository
+  class NotFoundError < StandardError; end
+
+  def self.set(ch_action_id, ak_action_id)
+    redis.set("action:#{ch_action_id}", ak_action_id)
+  end
+
+  def self.get(ch_action_id)
+    redis.get("action:#{ch_action_id}")
+  end
+
+  def self.get!(ch_action_id)
+    get(ch_action_id) || raise(NotFoundError.new "Can't find action with id: #{ch_action_id}")
+  end
+
+  def self.redis
+    RedisClient.client
+  end
+end

--- a/app/services/action_creator.rb
+++ b/app/services/action_creator.rb
@@ -20,7 +20,9 @@ class ActionCreator
     if action
       action[:form_data][:ak_resource_id] = response['resource_uri']
       action.save!
-      ActionRepository.set(params[:meta][:action_id], response['resource_uri'])
+      ActionRepository.set(params[:meta][:action_id],
+                           ak_id: response['resource_uri'],
+                           page_ak_id: response.parsed_response['page'])
     end
 
     Broadcast.emit(payload)

--- a/app/services/action_creator.rb
+++ b/app/services/action_creator.rb
@@ -1,0 +1,36 @@
+class ActionCreator
+  include Ak::Client
+  attr_reader :params
+
+  def self.run(params)
+    new(params).run
+  end
+
+  def initialize(params)
+    @params = params.clone
+  end
+
+  def run
+    params[:params][:mailing_id] = extract_mailing_id(params[:params][:akid])
+
+    action = Action.find_by_id(params[:meta][:action_id])
+    response = client.create_action(params[:params])
+    payload = params[:meta].merge(type: 'petition')
+
+    if action
+      action[:form_data][:ak_resource_id] = response['resource_uri']
+      action.save!
+      ActionRepository.set(params[:meta][:action_id], response['resource_uri'])
+    end
+
+    Broadcast.emit(payload)
+    ActionsCache.append(payload)
+    response
+  end
+
+  private
+
+  def extract_mailing_id(akid = '')
+    (akid.try(:split, '.') || []).first
+  end
+end

--- a/app/services/queue_listener.rb
+++ b/app/services/queue_listener.rb
@@ -11,6 +11,7 @@ class QueueListener
   CREATE_CAMPAIGN = 'create_campaign'
   UPDATE_CAMPAIGN = 'update_campaign'
   UPDATE_MEMBER = 'update_member'
+  NEW_SURVEY_RESPONSE = 'new_survey_response'
 
   def perform(sqs_message, params)
     case params[:type]
@@ -43,6 +44,9 @@ class QueueListener
 
       when SUBSCRIPTION_CANCELLATION
         cancel_subscription(params[:params])
+
+      when NEW_SURVEY_RESPONSE
+        SurveyResponseProcessor.run(params)
 
       else
         raise ArgumentError, "Unsupported message type: #{params[:type]}"

--- a/app/services/survey_response_processor.rb
+++ b/app/services/survey_response_processor.rb
@@ -1,0 +1,42 @@
+class SurveyResponseProcessor
+  class Error < StandardError; end
+
+  def self.run(params)
+    new(params).run
+  end
+
+  def initialize(params)
+    @params = params
+  end
+
+  def run
+   if new_action?
+     ActionCreator.run(@params)
+   else
+     update_action
+   end
+  end
+
+  private
+
+  def update_action
+    response = Ak::Client.client.update_petition_action(existing_action_ak_id, @params[:params])
+    if !response.success?
+      raise Error.new("HTTP Response code: #{response.code}, body: #{response.body}")
+    end
+    response
+  end
+
+  def new_action?
+    existing_action_ak_id.blank?
+  end
+
+  def existing_action_ak_id
+    @existing_action_ak_id ||= begin
+      resource_uri = ActionRepository.get(@params[:meta][:action_id])
+      if resource_uri.present?
+        ActionKitConnector::Util.extract_id_from_resource_uri(resource_uri)
+      end
+    end
+  end
+end

--- a/app/services/survey_response_processor.rb
+++ b/app/services/survey_response_processor.rb
@@ -19,24 +19,31 @@ class SurveyResponseProcessor
 
   private
 
+  def new_action?
+    ak_action.blank?
+  end
+
   def update_action
-    response = Ak::Client.client.update_petition_action(existing_action_ak_id, @params[:params])
+    response = Ak::Client.client.update_petition_action(existing_action_ak_id, update_params)
     if !response.success?
       raise Error.new("HTTP Response code: #{response.code}, body: #{response.body}")
     end
     response
   end
 
-  def new_action?
-    existing_action_ak_id.blank?
-  end
-
   def existing_action_ak_id
     @existing_action_ak_id ||= begin
-      resource_uri = ActionRepository.get(@params[:meta][:action_id])
-      if resource_uri.present?
-        ActionKitConnector::Util.extract_id_from_resource_uri(resource_uri)
-      end
+      ActionKitConnector::Util.extract_id_from_resource_uri(ak_action[:ak_id])
+    end
+  end
+
+  def ak_action
+    @ak_action ||= ActionRepository.get(@params[:meta][:action_id])
+  end
+
+  def update_params
+    @params[:params].clone.tap do |p|
+      p[:page] = @ak_action[:page_ak_id]
     end
   end
 end

--- a/app/services/survey_response_processor.rb
+++ b/app/services/survey_response_processor.rb
@@ -32,9 +32,8 @@ class SurveyResponseProcessor
   end
 
   def existing_action_ak_id
-    @existing_action_ak_id ||= begin
+    @existing_action_ak_id ||=
       ActionKitConnector::Util.extract_id_from_resource_uri(ak_action[:ak_id])
-    end
   end
 
   def ak_action

--- a/spec/lib/ak/client_spec.rb
+++ b/spec/lib/ak/client_spec.rb
@@ -2,14 +2,8 @@ require 'rails_helper'
 
 describe Ak::Client do
   describe 'client' do
-    before do
-      allow(ENV).to receive(:[]).with("AK_USERNAME"){"foo"}
-      allow(ENV).to receive(:[]).with("AK_PASSWORD"){"bar"}
-      allow(ENV).to receive(:[]).with("AK_HOST"){"http://foo.com"}
-    end
-
     it 'instantiates with credentials' do
-      expect(Ak::Client.client.credentials).to eq({password: 'bar', username: 'foo'})
+      expect(Ak::Client.client.credentials).to eq({password: ENV['AK_PASSWORD'], username: ENV['AK_USERNAME']})
     end
   end
 end

--- a/spec/requests/new_survey_response_spec.rb
+++ b/spec/requests/new_survey_response_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+describe "New Survey Response" do
+  before do
+    allow(Broadcast).to receive(:emit)
+    allow(ActionsCache).to receive(:append)
+  end
+
+  let(:action) { Action.create(form_data: {}) }
+
+  let(:params) do
+    {
+      type: 'new_survey_response',
+      params: data,
+      meta: {
+        foo: 'bar',
+        action_id: action.id
+      }
+    }
+  end
+
+  let(:data) do
+    {
+      page:         "/rest/v1/petitionpage/16483/",
+      name:         "Pablo José Francisco de María",
+      postal:       "W1",
+      address1:     "The Lodge",
+      address2:     "High Street",
+      city:         "London",
+      country:      "United Kingdom",
+      action_age:   "101",
+      action_foo:   "Foo",
+      action_bar:   "Bar",
+      ignored:      "ignore me",
+      email:        "omar@sumofus.org",
+      source:       'FB',
+      akid:         '3.4234.fsdf'
+    }
+  end
+
+  context "Given an action doesn't exist" do
+
+    before do
+      VCR.use_cassette("action_existing_page") do
+        post '/message', params
+      end
+    end
+
+    it 'responds successfully' do
+      expect(response).to be_success
+    end
+
+    it 'stores resource ID in champaign action' do
+      expect(action.reload.form_data['ak_resource_id']).to match(/rest\/v1\/petitionaction\//)
+    end
+
+    it 'stores the new action ak_id in the ActionsRepository' do
+      expect(ActionRepository.get(action.id)).to be_present
+    end
+  end
+
+  context "Given the action already exists" do
+    let(:update_params) do
+      params.clone.tap do |p|
+        p[:params][:action_question_1] = '123'
+      end
+    end
+
+    before do
+      # Create action
+      VCR.use_cassette("action_existing_page") do
+        post '/message', params
+      end
+      expect(response.success?).to be_truthy
+
+      resource_uri = ActionRepository.get(action.id)
+      @action_ak_id = ActionKitConnector::Util.extract_id_from_resource_uri(resource_uri)
+    end
+
+    it "updates action kit" do
+      expect(Ak::Client.client).to receive(:update_petition_action).with(@action_ak_id, update_params[:params]).and_call_original
+      VCR.use_cassette("update_petition_action") do
+        post '/message', update_params
+      end
+    end
+
+    it "responds successfully" do
+      VCR.use_cassette("update_petition_action") do
+        post '/message', update_params
+      end
+
+      expect(response).to be_success
+    end
+  end
+end

--- a/spec/requests/new_survey_response_spec.rb
+++ b/spec/requests/new_survey_response_spec.rb
@@ -51,12 +51,12 @@ describe "New Survey Response" do
     end
 
     it 'stores resource ID in champaign action' do
-      expect(action.reload.form_data['ak_resource_id']).to match(/rest\/v1\/petitionaction\//)
+      expect(action.reload.form_data['ak_resource_id']).to match(%r{rest\/v1\/petitionaction\/})
     end
 
     it 'stores the new action data in the ActionsRepository' do
       ak_action = ActionRepository.get(action.id)
-      expect(ak_action[:page_ak_id]).to match(/rest\/v1\/petitionpage\//)
+      expect(ak_action[:page_ak_id]).to match(%r{rest\/v1\/petitionpage\/})
       expect(ak_action[:ak_id]).to be_present
     end
   end

--- a/spec/vcr_cassettes/update_petition_action.yml
+++ b/spec/vcr_cassettes/update_petition_action.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/petitionaction/61821024/
+    body:
+      encoding: UTF-8
+      string: '{"page":"/rest/v1/petitionpage/16483/","name":"Pablo José Francisco
+        de María","postal":"W1","address1":"The Lodge","address2":"High Street","city":"London","country":"United
+        Kingdom","action_age":"101","action_foo":"Foo","action_bar":"Bar","ignored":"ignore
+        me","email":"omar@sumofus.org","source":"FB","akid":"3.4234.fsdf","action_question_1":"123"}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 204
+      message: NO CONTENT
+    headers:
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 13 Oct 2016 15:42:13 GMT
+      Server:
+      - nginx
+      Set-Cookie:
+      - sid=mh8ek8byrk02mjyecd0sxrilyp8xbf5j; expires=Thu, 13-Oct-2016 23:42:13 GMT;
+        httponly; Max-Age=28800; Path=/
+      Vary:
+      - Accept,Cookie,Accept-Encoding,User-Agent
+      X-Machine-Id:
+      - ip-10-50-2-90
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 13 Oct 2016 15:42:13 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/update_petition_action.yml
+++ b/spec/vcr_cassettes/update_petition_action.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/petitionaction/61821024/
     body:
       encoding: UTF-8
-      string: '{"page":"/rest/v1/petitionpage/16483/","name":"Pablo José Francisco
+      string: '{"page":"/rest/v1/petitionpage/8651/","name":"Pablo José Francisco
         de María","postal":"W1","address1":"The Lodge","address2":"High Street","city":"London","country":"United
         Kingdom","action_age":"101","action_foo":"Foo","action_bar":"Bar","ignored":"ignore
         me","email":"omar@sumofus.org","source":"FB","akid":"3.4234.fsdf","action_question_1":"123"}'
@@ -24,21 +24,21 @@ http_interactions:
       Content-Type:
       - text/plain
       Date:
-      - Thu, 13 Oct 2016 15:42:13 GMT
+      - Fri, 14 Oct 2016 18:33:29 GMT
       Server:
       - nginx
       Set-Cookie:
-      - sid=mh8ek8byrk02mjyecd0sxrilyp8xbf5j; expires=Thu, 13-Oct-2016 23:42:13 GMT;
+      - sid=0urs8q459l2tjs88pud5eh8ocu35ic64; expires=Sat, 15-Oct-2016 02:33:29 GMT;
         httponly; Max-Age=28800; Path=/
       Vary:
       - Accept,Cookie,Accept-Encoding,User-Agent
       X-Machine-Id:
-      - ip-10-50-2-90
+      - ip-10-50-1-128
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 15:42:13 GMT
+  recorded_at: Fri, 14 Oct 2016 18:33:30 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
* Add processing for `new_survey_response` events
  * If the action doesn't exist in AK, then we create a new action.
  * If the action already exists in AK, then we update it.

* When an action is created we're storing in Redis a map of champaign_id => ak_id. This allows to check if an action already exists in AK, and also allows to get the ak_id only knowing the champaign_id. All of this without accessing the Champaign DB. 

Needed for this PR: https://github.com/SumOfUs/actionkit_connector/pull/10