### PR TITLE
Growth tracking fix

### DIFF
--- a/spec/services/action_creator_spec.rb
+++ b/spec/services/action_creator_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe ActionCreator do
+  context "given referring_akid is present" do
+    around(:example) do |example|
+      VCR.use_cassette('ActionCreator with referring_akid 200') do
+        example.run
+      end
+    end
+
+    let(:params) do
+      {
+        params: {
+          :email => "test@sou.com",
+          :page => 'petition-test-rodri-petition',
+          :referring_akid => '35578.11727499.ygNy8N'
+        },
+        meta: {}
+      }
+    end
+
+    it "creates the action on AK" do
+      expect_any_instance_of(ActionKitConnector::Client).to receive(:create_action)
+        .with(hash_including(params[:params]))
+        .and_call_original
+      response = ActionCreator.run(params)
+      expect(response).to be_success
+    end
+
+    it "updates the action on AK after creating it nullifying the mailing_id" do
+      expect_any_instance_of(ActionKitConnector::Client).to receive(:update_petition_action)
+        .with(instance_of(String), mailing: nil)
+        .and_call_original
+      response = ActionCreator.run(params)
+      expect(response).to be_success
+    end
+  end
+end

--- a/spec/vcr_cassettes/ActionCreator_with_referring_akid_200.yml
+++ b/spec/vcr_cassettes/ActionCreator_with_referring_akid_200.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/action/
+    body:
+      encoding: UTF-8
+      string: '{"email":"test@sou.com","page":"petition-test-rodri-petition","referring_akid":"35578.11727499.ygNy8N","mailing_id":null}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Thu, 21 Dec 2017 00:16:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      X-Machine-Id:
+      - ip-10-50-1-77
+      X-Handled-For:
+      - 190.194.200.217
+      Vary:
+      - Accept,Cookie,Accept-Encoding,User-Agent
+      Location:
+      - https://act.sumofus.org/rest/v1/petitionaction/95878314/
+    body:
+      encoding: UTF-8
+      string: '{"akid": "35578.14220077.4687fQ", "created_at": "2017-12-21T00:16:01.756340",
+        "created_user": false, "fields": {}, "id": 95878314, "ip_address": "190.194.200.217",
+        "is_forwarded": true, "link": null, "mailing": "/rest/v1/mailing/35578/",
+        "opq_id": "", "page": "/rest/v1/petitionpage/19891/", "redirect_url": "/cms/thanks/petition-test-rodri-petition?action_id=95878314&akid=35578.14220077.4687fQ&ar=1&rd=1",
+        "referring_mailing": "/rest/v1/mailing/35578/", "referring_user": "/rest/v1/user/11727499/",
+        "resource_uri": "/rest/v1/petitionaction/95878314/", "source": "restful_api",
+        "status": "complete", "subscribed_user": false, "taf_emails_sent": null, "type":
+        "Petition", "updated_at": "2017-12-21T00:16:01.781799", "user": "/rest/v1/user/14220077/"}'
+    http_version: 
+  recorded_at: Thu, 21 Dec 2017 00:16:01 GMT
+- request:
+    method: put
+    uri: https://<AK_USERNAME>:<AK_PASSWORD>@act.sumofus.org/rest/v1/petitionaction/95878314/
+    body:
+      encoding: UTF-8
+      string: '{"mailing":null}'
+    headers:
+      Content-Type:
+      - application/json
+      Charset:
+      - UTF-8
+  response:
+    status:
+      code: 204
+      message: NO CONTENT
+    headers:
+      Date:
+      - Thu, 21 Dec 2017 00:16:03 GMT
+      Content-Type:
+      - text/plain
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      X-Machine-Id:
+      - ip-10-50-1-88
+      X-Handled-For:
+      - 190.194.200.217
+      Vary:
+      - Accept,Cookie,Accept-Encoding,User-Agent
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 21 Dec 2017 00:16:03 GMT
+recorded_with: VCR 3.0.1

--- a/spec/workers/queue_listener_spec.rb
+++ b/spec/workers/queue_listener_spec.rb
@@ -4,7 +4,7 @@ describe QueueListener do
   let(:client) { double }
 
   before do
-    allow(ActionKitConnector::Client).to receive(:new){ client }
+    allow(ActionKitConnector::Client).to receive(:new) { client }
   end
 
   subject { QueueListener.new }


### PR DESCRIPTION
Updating action on AK to nullify the mailing_id set incorrectly when referring_akid is present.

Long version: when creating an action with `referring_akid`, AK sets the `referring_mailing_id` and `referring_user_id` from it. Unexpectedly, it also sets the `mailing_id` to be the one in the `referring_akid`. This last behaviour breaks our reports, and changes the definition of action rate across the board. To avoid this, and still be able to track referrals, I'm nullifying the `mailing_id` field after creating an action. (Creating an action with a referring_akid and setting the mailing_id to null in one request is not allowed by AK's API).

Please don't merge yet, Tara needs to QA this on staging first. And btw, I deployed this to staging but Champaign (staging) is not pushing events to the worker, so I need to figure out what's going on there. 