### PR TITLE
Inject random string into page name to ensure name uniqueness

### DIFF
--- a/app/services/page_creator.rb
+++ b/app/services/page_creator.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class PageCreator
   class Error < StandardError; end
 
@@ -12,6 +14,8 @@ class PageCreator
 
   def run
     @page = Page.find @page_id
+    unique_string = SecureRandom.hex(3)
+    @params[:name] = "#{@params[:name]}-#{unique_string}"
     Donation.run(@page, @params)
     Petition.run(@page, @params)
     unless @page.ak_donation_resource_uri.blank? || @page.ak_petition_resource_uri.blank?

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
-
 require 'rails_helper'
+require 'securerandom'
 
 describe 'REST' do
   let(:language) { Language.create(code: 'en', name: 'English') }
   let(:page) { Page.create(title: 'Foo', slug: 'foo-bar', language: language) }
 
   before do
+    allow(SecureRandom).to(receive(:hex)).and_return("xyz")
     allow_any_instance_of(ActionKitConnector::Client).to(
       receive(:create_petitionform).and_return(double(success?: true))
     )
@@ -174,7 +175,7 @@ describe 'REST' do
           receive(:create_donation_page)
           .with(
             page_id: page.id,
-            name: 'this-page-does-not-exist-13172406-donation',
+            name: 'this-page-does-not-exist-13172406-xyz-donation',
             title: 'Foo Bar (Donation)',
             language: '/rest/v1/language/100/',
             page_type: 'donation',
@@ -189,7 +190,7 @@ describe 'REST' do
           receive(:create_petition_page)
           .with(
             page_id: page.id,
-            name: 'this-page-does-not-exist-13172406-petition',
+            name: 'this-page-does-not-exist-13172406-xyz-petition',
             title: 'Foo Bar (Petition)',
             language: '/rest/v1/language/100/',
             page_type: 'petition',

--- a/spec/services/page_creator_spec.rb
+++ b/spec/services/page_creator_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
+require 'securerandom'
 
 describe PageCreator do
-
+  before { allow(SecureRandom).to(receive(:hex)).and_return("xyz") }
   let!(:language) { Language.create(code: 'en', name: 'English') }
 
   context "when neither a donation or petition page exists (not a retry)" do
@@ -31,13 +32,13 @@ describe PageCreator do
     )}
 
     petition_page_params = {
-      name: 'super-random-horsey-pony-petition',
+      name: 'super-random-horsey-pony-xyz-petition',
       title: 'Vote for this super random horsey pony! (Petition)',
       page_type: 'petition',
       multilingual_campaign: nil
     }
     donation_page_params = {
-      name: 'super-random-horsey-pony-donation',
+      name: 'super-random-horsey-pony-xyz-donation',
       title: 'Vote for this super random horsey pony! (Donation)',
       page_type: 'donation',
       multilingual_campaign: nil,
@@ -115,7 +116,7 @@ describe PageCreator do
     it "doesn't error out before creating the missing resource" do
       ak_client_params = {
         page_id: 4699,
-        name: "aidez-nous-a-reveler-le-cruel-secret-des-poussins-de-mcdonald-s-1-petition",
+        name: "aidez-nous-a-reveler-le-cruel-secret-des-poussins-de-mcdonald-s-1-xyz-petition",
         title: "Aidez-nous à révéler le cruel secret des poussins de McDonald's (Petition)",
         language: "/rest/v1/language/100/",
         tags: nil,


### PR DESCRIPTION
This'll help fix the name conflict issue campaigners keep hitting.