### PR TITLE
AWS secrets patch

### DIFF
--- a/config/initializers/application_secrets.rb
+++ b/config/initializers/application_secrets.rb
@@ -1,13 +1,12 @@
 require './app/lib/secrets_manager'
 
-if Rails.env == 'fakeEnv'
+if Rails.env == 'production'
   ak_secrets = SecretsManager.get_value('prod/actionKitApi')
   database_secrets = SecretsManager.get_value('champaignDB')
   share_progress_secrets = SecretsManager.get_value('shareProgressApi')
   champaign_secrets = SecretsManager.get_value('champaign')
   airbrake_secrets = SecretsManager.get_value('akWorkerAirbrake');
   devise_secrets = SecretsManager.get_value('prod/deviseSecret');
-  key_base_secrets = SecretsManager.get_value('akWorkerSecretKeyBase');
 
   ENV['AK_USERNAME'] = ak_secrets['username']
   ENV['AK_PASSWORD'] = ak_secrets['password']
@@ -26,5 +25,4 @@ if Rails.env == 'fakeEnv'
   ENV['AIRBRAKE_PROJECT_ID'] = airbrake_secrets['projectId']
 
   ENV['DEVISE_SECRET_KEY'] = devise_secrets['secretKey']
-  ENV['SECRET_KEY_BASE'] = key_base_secrets['secretKeyBase']
 end


### PR DESCRIPTION
### Overview
We had an issue with the past aws secrets manager changes, they were causing the application to crash.
This PR is intended to avoid that crash.

Since this repo is not using settings as Champaign does, I'll keep the secret_key_base as it was (with the env variable instead of using the secrets manager)