### PR TITLE
Fixing dynamo query

### DIFF
--- a/app/services/get_constituency.rb
+++ b/app/services/get_constituency.rb
@@ -20,7 +20,9 @@ class GetConstituency
     {
       table_name: table_name,
       key: {
-        postcode: @postcode
+        "postcode" => {
+          s: @postcode
+        }
       }
     }
   end


### PR DESCRIPTION
There are a lot of error logs like this one:
````
E, [2024-08-05T16:03:09.259310 #9] ERROR -- : [9ba51f4e-bea2-4876-a0f8-cf358915c40e] Failed to get constituency: The provided key element does not match the schema
````
According to the [docs](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/DynamoDB/Client.html#get_item-instance_method), I looked at the code, and the culprit is an incorrectly formed Dynamo query.

Fixing the query should fix the issues.