### PR TITLE
adjust db get-item schema

### DIFF
--- a/app/services/get_constituency.rb
+++ b/app/services/get_constituency.rb
@@ -11,6 +11,7 @@ class GetConstituency
   end
 
   def get
+    return nil if @postcode.nil? || @postcode.empty?
     @client.get_item(options).item&.fetch('constituency', nil)
   end
 

--- a/app/services/get_constituency.rb
+++ b/app/services/get_constituency.rb
@@ -20,9 +20,7 @@ class GetConstituency
     {
       table_name: table_name,
       key: {
-        "postcode" => {
-          s: @postcode
-        }
+        postcode: @postcode
       }
     }
   end


### PR DESCRIPTION
See docs here: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/DynamoDB/Table.html#get_item-instance_method

```ruby
table.get_item({
  key: { # required
    "AttributeName" => "value", # value <Hash,Array,String,Numeric,Boolean,IO,Set,nil>
  },
  attributes_to_get: ["AttributeName"],
  consistent_read: false,
  return_consumed_capacity: "INDEXES", # accepts INDEXES, TOTAL, NONE
  projection_expression: "ProjectionExpression",
  expression_attribute_names: {
    "ExpressionAttributeNameVariable" => "AttributeName",
  },
})
```